### PR TITLE
Proposal for replacing OtaErr_t with enums (review only)

### DIFF
--- a/source/include/ota_http_interface.h
+++ b/source/include/ota_http_interface.h
@@ -35,10 +35,10 @@
  */
 typedef enum OtaHttpStatus
 {
-    OtaErrHttpSuccess = 0,       /*!< OTA HTTP interface success. */
-    OtaErrHttpInitFailed = 0xc0, /*!< Error initializing the HTTP connection. */
-    OtaErrHttpDeinitFailed,      /*!< Error deinitializing the HTTP connection. */
-    OtaErrHttpRequestFailed      /*!< Error sending the HTTP request. */
+    OtaHttpSuccess = 0,       /*!< OTA HTTP interface success. */
+    OtaHttpInitFailed = 0xc0, /*!< Error initializing the HTTP connection. */
+    OtaHttpDeinitFailed,      /*!< Error deinitializing the HTTP connection. */
+    OtaHttpRequestFailed      /*!< Error sending the HTTP request. */
 } OtaHttpStatus_t;
 
 /**
@@ -48,7 +48,7 @@ typedef enum OtaHttpStatus
  *
  * @param[in] pUrl         Pointer to the pre-signed url for downloading update file.
  *
- * @return              OtaErrHttpSuccess if success , other error code on failure.
+ * @return              OtaHttpSuccess if success , other error code on failure.
  */
 
 typedef OtaHttpStatus_t ( * ota_HttpInit_t ) ( char * pUrl );
@@ -62,7 +62,7 @@ typedef OtaHttpStatus_t ( * ota_HttpInit_t ) ( char * pUrl );
  *
  * @param[in] rangeEnd    End index of the file data to be requested.
  *
- * @return             OtaErrHttpSuccess if success , other error code on failure.
+ * @return             OtaHttpSuccess if success , other error code on failure.
  */
 
 typedef OtaHttpStatus_t ( * ota_HttpRequest_t )  ( uint32_t rangeStart,
@@ -74,7 +74,7 @@ typedef OtaHttpStatus_t ( * ota_HttpRequest_t )  ( uint32_t rangeStart,
  * This function cleanups Http connection and other data used for
  * requesting file blocks using the pre-signed url.
  *
- * @return        OtaErrHttpSuccess if success , other error code on failure.
+ * @return        OtaHttpSuccess if success , other error code on failure.
  */
 typedef OtaHttpStatus_t ( * ota_HttpDeinit )( void );
 

--- a/source/include/ota_http_interface.h
+++ b/source/include/ota_http_interface.h
@@ -31,9 +31,15 @@
 #include <stdint.h>
 
 /**
- * @brief OTA Error type.
+ * @brief The OTA HTTP interface return status.
  */
-typedef uint32_t OtaErr_t;
+typedef enum OtaHttpStatus
+{
+    OtaErrHttpSuccess = 0,       /*!< OTA HTTP interface success. */
+    OtaErrHttpInitFailed = 0xc0, /*!< Error initializing the HTTP connection. */
+    OtaErrHttpDeinitFailed,      /*!< Error deinitializing the HTTP connection. */
+    OtaErrHttpRequestFailed      /*!< Error sending the HTTP request. */
+} OtaHttpStatus_t;
 
 /**
  * @brief Init OTA Http interface.
@@ -42,10 +48,10 @@ typedef uint32_t OtaErr_t;
  *
  * @param[in] pUrl         Pointer to the pre-signed url for downloading update file.
  *
- * @return              OTA_ERR_NONE if success , other error code on failure.
+ * @return              OtaErrHttpSuccess if success , other error code on failure.
  */
 
-typedef OtaErr_t ( * ota_HttpInit_t ) ( char * pUrl );
+typedef OtaHttpStatus_t ( * ota_HttpInit_t ) ( char * pUrl );
 
 /**
  * @brief Request file block over Http.
@@ -56,11 +62,11 @@ typedef OtaErr_t ( * ota_HttpInit_t ) ( char * pUrl );
  *
  * @param[in] rangeEnd    End index of the file data to be requested.
  *
- * @return             OTA_ERR_NONE if success , other error code on failure.
+ * @return             OtaErrHttpSuccess if success , other error code on failure.
  */
 
-typedef OtaErr_t ( * ota_HttpRequest_t )  ( uint32_t rangeStart,
-                                            uint32_t rangeEnd );
+typedef OtaHttpStatus_t ( * ota_HttpRequest_t )  ( uint32_t rangeStart,
+                                                   uint32_t rangeEnd );
 
 /**
  * @brief Deinit OTA Http interface.
@@ -68,9 +74,9 @@ typedef OtaErr_t ( * ota_HttpRequest_t )  ( uint32_t rangeStart,
  * This function cleanups Http connection and other data used for
  * requesting file blocks using the pre-signed url.
  *
- * @return        OTA_ERR_NONE if success , other error code on failure.
+ * @return        OtaErrHttpSuccess if success , other error code on failure.
  */
-typedef OtaErr_t ( * ota_HttpDeinit )( void );
+typedef OtaHttpStatus_t ( * ota_HttpDeinit )( void );
 
 /**
  * @brief OTA Event Interface structure.

--- a/source/include/ota_mqtt_interface.h
+++ b/source/include/ota_mqtt_interface.h
@@ -31,9 +31,15 @@
 #include <stdint.h>
 
 /**
- * @brief OTA Error type.
+ * @brief The OTA MQTT interface return status.
  */
-typedef uint32_t OtaErr_t;
+typedef enum OtaMqttStatus
+{
+    OtaMqttSuccess = 0,          /*!< OTA MQTT interface success. */
+    OtaMqttPublishFailed = 0xa0, /*!< Attempt to publish a MQTT message failed. */
+    OtaMqttSubscribeFailed,      /*!< Failed to subscribe to a topic. */
+    OtaMqttUnsubscribeFailed     /*!< Failed to unsubscribe from a topic. */
+} OtaMqttStatus_t;
 
 /**
  * @brief OTA Mqtt callback.
@@ -55,13 +61,13 @@ typedef void ( * OtaMqttCallback_t )( void * pvParam );
  *
  * @param[pvCallback]           Callback to be registered.
  *
- * @return                      OTA_OS_ERR_OK if success , other error code on failure.
+ * @return                      OtaMqttSuccess if success , other error code on failure.
  */
 
-typedef OtaErr_t ( * OtaMqttSubscribe_t ) ( const char * pTopicFilter,
-                                            uint16_t topicFilterLength,
-                                            uint8_t ucQoS,
-                                            OtaMqttCallback_t callback );
+typedef OtaMqttStatus_t ( * OtaMqttSubscribe_t ) ( const char * pTopicFilter,
+                                                   uint16_t topicFilterLength,
+                                                   uint8_t ucQoS,
+                                                   OtaMqttCallback_t callback );
 
 /**
  * @brief Unsubscribe to the Mqtt topics.
@@ -75,12 +81,12 @@ typedef OtaErr_t ( * OtaMqttSubscribe_t ) ( const char * pTopicFilter,
  *
  * @param[ucQoS]                Quality of Service
  *
- * @return                      OTA_OS_ERR_OK if success , other error code on failure.
+ * @return                      OtaMqttSuccess if success , other error code on failure.
  */
 
-typedef OtaErr_t ( * OtaMqttUnsubscribe_t )  ( const char * pTopicFilter,
-                                               uint16_t topicFilterLength,
-                                               uint8_t ucQoS );
+typedef OtaMqttStatus_t ( * OtaMqttUnsubscribe_t )  ( const char * pTopicFilter,
+                                                      uint16_t topicFilterLength,
+                                                      uint8_t ucQoS );
 
 /**
  * @brief Publish message to a topic.
@@ -97,13 +103,13 @@ typedef OtaErr_t ( * OtaMqttUnsubscribe_t )  ( const char * pTopicFilter,
  *
  * @param[ucQoS]                Quality of Service
  *
- * @return                      OTA_OS_ERR_OK if success , other error code on failure.
+ * @return                      OtaMqttSuccess if success , other error code on failure.
  */
-typedef OtaErr_t ( * OtaMqttPublish_t )( const char * const pacTopic,
-                                         uint16_t usTopicLen,
-                                         const char * pcMsg,
-                                         uint32_t ulMsgSize,
-                                         uint8_t ucQos );
+typedef OtaMqttStatus_t ( * OtaMqttPublish_t )( const char * const pacTopic,
+                                                uint16_t usTopicLen,
+                                                const char * pcMsg,
+                                                uint32_t ulMsgSize,
+                                                uint8_t ucQos );
 
 /**
  *  OTA Event Interface structure.

--- a/source/include/ota_os_interface.h
+++ b/source/include/ota_os_interface.h
@@ -26,8 +26,6 @@
 #ifndef _OTA_OS_INTERFACE_H_
 #define _OTA_OS_INTERFACE_H_
 
-typedef uint32_t                 OtaErr_t;
-
 struct OtaEventContext;
 typedef struct OtaEventContext   OtaEventContext_t;
 
@@ -42,16 +40,33 @@ typedef enum
 } OtaTimerId_t;
 
 /**
+ * @brief The OTA OS interface return status.
+ */
+typedef enum OtaOsStatus
+{
+    OtaOsSuccess = 0,                    /*!< OTA OS interface success. */
+    OtaOsEventQueueCreateFailed = 0x80U, /*!< Failed to create the event queue. */
+    OtaOsEventQueueSendFailed,           /*!< Posting event message to the event queue failed. */
+    OtaOsEventQueueReceiveFailed,        /*!< Failed to receive from the event queue. */
+    OtaOsEventQueueDeleteFailed,         /*!< Failed to delete the event queue. */
+    OtaOsTimerCreateFailed,              /*!< Failed to create the timer. */
+    OtaOsTimerStartFailed,               /*!< Failed to create the timer. */
+    OtaOsTimerRestartFailed,             /*!< Failed to restart the timer. */
+    OtaOsTimerStopFailed,                /*!< Failed to stop the timer. */
+    OtaOsTimerDeleteFailed               /*!< Failed to delete the timer. */
+} OtaOsStatus_t;
+
+/**
  * @brief Initialize the OTA events.
  *
  * This function initializes the OTA events mechanism.
  *
  * @param[pEventCtx]     Pointer to the OTA event context.
  *
- * @return               OtaErr_t, OTA_ERR_NONE if success , other error code on failure.
+ * @return               OtaOsStatus_t, OtaOsSuccess if success , other error code on failure.
  */
 
-typedef OtaErr_t ( * OtaInitEvent_t ) ( OtaEventContext_t * pEventCtx );
+typedef OtaOsStatus_t ( * OtaInitEvent_t ) ( OtaEventContext_t * pEventCtx );
 
 /**
  * @brief Sends an OTA event.
@@ -64,12 +79,12 @@ typedef OtaErr_t ( * OtaInitEvent_t ) ( OtaEventContext_t * pEventCtx );
  *
  * @param[timeout]       The maximum amount of time (msec) the task should block.
  *
- * @return               OtaErr_t, OTA_ERR_NONE if success , other error code on failure.
+ * @return               OtaOsStatus_t, OtaOsSuccess if success , other error code on failure.
  */
 
-typedef OtaErr_t ( * OtaSendEvent_t )( OtaEventContext_t * pEventCtx,
-                                       const void * pEventMsg,
-                                       unsigned int timeout );
+typedef OtaOsStatus_t ( * OtaSendEvent_t )( OtaEventContext_t * pEventCtx,
+                                            const void * pEventMsg,
+                                            unsigned int timeout );
 
 /**
  * @brief Receive an OTA event.
@@ -82,12 +97,12 @@ typedef OtaErr_t ( * OtaSendEvent_t )( OtaEventContext_t * pEventCtx,
  *
  * @param[timeout]       The maximum amount of time the task should block.
  *
- * @return               OtaErr_t, OTA_ERR_NONE if success , other error code on failure.
+ * @return               OtaOsStatus_t, OtaOsSuccess if success , other error code on failure.
  */
 
-typedef OtaErr_t ( * OtaReceiveEvent_t )( OtaEventContext_t * pEventCtx,
-                                          void * pEventMsg,
-                                          uint32_t timeout );
+typedef OtaOsStatus_t ( * OtaReceiveEvent_t )( OtaEventContext_t * pEventCtx,
+                                               void * pEventMsg,
+                                               uint32_t timeout );
 
 /**
  * @brief Deinitialize the OTA Events mechanism.
@@ -97,10 +112,10 @@ typedef OtaErr_t ( * OtaReceiveEvent_t )( OtaEventContext_t * pEventCtx,
  *
  * @param[pEventCtx]     Pointer to the OTA event context.
  *
- * @return               OtaErr_t, OTA_ERR_NONE if success , other error code on failure.
+ * @return               OtaOsStatus_t, OtaOsSuccess if success , other error code on failure.
  */
 
-typedef OtaErr_t ( * OtaDeinitEvent_t )( OtaEventContext_t * pEventCtx );
+typedef OtaOsStatus_t ( * OtaDeinitEvent_t )( OtaEventContext_t * pEventCtx );
 
 /**
  * @brief Timer callback.
@@ -109,7 +124,7 @@ typedef OtaErr_t ( * OtaDeinitEvent_t )( OtaEventContext_t * pEventCtx );
  *
  * @param[otaTimerId]       Timer ID of type otaTimerId_t
  *
- * @return                  OtaErr_t, OTA_ERR_NONE if success , other error code on failure.
+ * @return                  OtaOsStatus_t, OtaOsSuccess if success , other error code on failure.
  */
 
 typedef void ( * OtaTimerCallback_t )( OtaTimerId_t otaTimerId );
@@ -127,13 +142,13 @@ typedef void ( * OtaTimerCallback_t )( OtaTimerId_t otaTimerId );
  *
  * @param[callback]         Callback to be called when timer expires.
  *
- * @return                  OtaErr_t, OTA_ERR_NONE if success , other error code on failure.
+ * @return                  OtaOsStatus_t, OtaOsSuccess if success , other error code on failure.
  */
 
-typedef OtaErr_t ( * OtaStartTimer_t ) ( OtaTimerId_t otaTimerId,
-                                         const char * const pTimerName,
-                                         const uint32_t timeout,
-                                         OtaTimerCallback_t callback );
+typedef OtaOsStatus_t ( * OtaStartTimer_t ) ( OtaTimerId_t otaTimerId,
+                                              const char * const pTimerName,
+                                              const uint32_t timeout,
+                                              OtaTimerCallback_t callback );
 
 /**
  * @brief Stop timer.
@@ -142,10 +157,10 @@ typedef OtaErr_t ( * OtaStartTimer_t ) ( OtaTimerId_t otaTimerId,
  *
  * @param[otaTimerId]     Timer ID of type otaTimerId_t
  *
- * @return                OtaErr_t, OTA_ERR_NONE if success , other error code on failure.
+ * @return                OtaOsStatus_t, OtaOsSuccess if success , other error code on failure.
  */
 
-typedef OtaErr_t ( * OtaStopTimer_t ) ( OtaTimerId_t otaTimerId );
+typedef OtaOsStatus_t ( * OtaStopTimer_t ) ( OtaTimerId_t otaTimerId );
 
 /**
  * @brief Delete a timer.
@@ -154,10 +169,10 @@ typedef OtaErr_t ( * OtaStopTimer_t ) ( OtaTimerId_t otaTimerId );
  *
  * @param[otaTimerId]       Timer ID of type otaTimerId_t
  *
- * @return                  OtaErr_t, OTA_ERR_NONE if success , other error code on failure.
+ * @return                  OtaOsStatus_t, OtaOsSuccess if success , other error code on failure.
  */
 
-typedef OtaErr_t ( * OtaDeleteTimer_t ) ( OtaTimerId_t otaTimerId );
+typedef OtaOsStatus_t ( * OtaDeleteTimer_t ) ( OtaTimerId_t otaTimerId );
 
 /**
  * @brief Allocate memory.

--- a/source/include/ota_platform_interface.h
+++ b/source/include/ota_platform_interface.h
@@ -29,9 +29,24 @@
 #include "ota_private.h"
 
 /**
- * @brief OTA Error type.
+ * @brief The OTA platform interface return status.
  */
-typedef uint32_t OtaErr_t;
+typedef enum OtaPalStatus
+{
+    OtaPalSuccess = 0,                 /*!< OTA platform interface success. */
+    OtaPalSignatureCheckFailed = 0xe0, /*!< The signature check failed for the specified file. */
+    OtaPalRxFileCreateFailed,          /*!< The PAL failed to create the OTA receive file. */
+    OtaPalRxFileTooLarge,              /*!< The OTA receive file is too big for the platform to support. */
+    OtaPalBootInfoCreateFailed,        /*!< The PAL failed to create the OTA boot info file. */
+    OtaPalBadSignerCert,               /*!< The signer certificate was not readable or zero length. */
+    OtaPalBadImageState,               /*!< The specified OTA image state was out of range. */
+    OtaPalAbortFailed,                 /*!< Error trying to abort the OTA. */
+    OtaPalRejectFailed,                /*!< Error trying to reject the OTA image. */
+    OtaPalCommitFailed,                /*!< The acceptance commit of the new OTA image failed. */
+    OtaPalActivateFailed,              /*!< The activation of the new OTA image failed. */
+    OtaPalFileAbort,                   /*!< Error in low level file abort. */
+    OtaPalFileClose                    /*!< Error in low level file close. */
+} OtaPalStatus_t;
 
 /**
  * @brief Abort an OTA transfer.
@@ -50,10 +65,10 @@ typedef uint32_t OtaErr_t;
  * error codes information in ota.h.
  *
  * The file pointer will be set to NULL after this function returns.
- * OTA_ERR_NONE is returned when aborting access to the open file was successful.
- * OTA_ERR_FILE_ABORT is returned when aborting access to the open file context was unsuccessful.
+ * OtaPalSuccess is returned when aborting access to the open file was successful.
+ * OtaPalFileAbort is returned when aborting access to the open file context was unsuccessful.
  */
-typedef OtaErr_t ( * OtaPalAbort_t )( OtaFileContext_t * const pFileContext );
+typedef OtaPalStatus_t ( * OtaPalAbort_t )( OtaFileContext_t * const pFileContext );
 
 /**
  * @brief Create a new receive file for the data chunks as they come in.
@@ -73,12 +88,12 @@ typedef OtaErr_t ( * OtaPalAbort_t )( OtaFileContext_t * const pFileContext );
  * @return The OTA PAL layer error code combined with the MCU specific error code. See OTA Agent
  * error codes information in ota.h.
  *
- * OTA_ERR_NONE is returned when file creation is successful.
- * OTA_ERR_RX_FILE_TOO_LARGE is returned if the file to be created exceeds the device's non-volatile memory size constraints.
- * OTA_ERR_BOOT_INFO_CREATE_FAILED is returned if the bootloader information file creation fails.
- * OTA_ERR_RX_FILE_CREATE_FAILED is returned for other errors creating the file in the device's non-volatile memory.
+ * OtaPalSuccess is returned when file creation is successful.
+ * OtaPalRxFileTooLarge is returned if the file to be created exceeds the device's non-volatile memory size constraints.
+ * OtaPalBootInfoCreateFailed is returned if the bootloader information file creation fails.
+ * OtaPalRxFileCreateFailed is returned for other errors creating the file in the device's non-volatile memory.
  */
-typedef OtaErr_t (* OtaPalCreateFileForRx_t)( OtaFileContext_t * const pFileContext );
+typedef OtaPalStatus_t (* OtaPalCreateFileForRx_t)( OtaFileContext_t * const pFileContext );
 
 /* @brief Authenticate and close the underlying receive file in the specified OTA context.
  *
@@ -98,12 +113,12 @@ typedef OtaErr_t (* OtaPalCreateFileForRx_t)( OtaFileContext_t * const pFileCont
  * @return The OTA PAL layer error code combined with the MCU specific error code. See OTA Agent
  * error codes information in ota.h.
  *
- * OTA_ERR_NONE is returned on success.
- * OTA_ERR_SIGNATURE_CHECK_FAILED is returned when cryptographic signature verification fails.
- * OTA_ERR_BAD_SIGNER_CERT is returned for errors in the certificate itself.
- * OTA_ERR_FILE_CLOSE is returned when closing the file fails.
+ * OtaPalSuccess is returned on success.
+ * OtaPalSignatureCheckFailed is returned when cryptographic signature verification fails.
+ * OtaPalBadSignerCert is returned for errors in the certificate itself.
+ * OtaPalFileClose is returned when closing the file fails.
  */
-typedef OtaErr_t ( * OtaPalCloseFile_t )( OtaFileContext_t * const pFileContext );
+typedef OtaPalStatus_t ( * OtaPalCloseFile_t )( OtaFileContext_t * const pFileContext );
 
 /**
  * @brief Write a block of data to the specified file at the given offset.
@@ -141,7 +156,7 @@ typedef int16_t ( * OtaPalWriteBlock_t ) ( OtaFileContext_t * const pFileContext
  * @return The OTA PAL layer error code combined with the MCU specific error code. See OTA Agent
  * error codes information in ota.h.
  */
-typedef OtaErr_t ( * OtaPalActivateNewImage_t )( OtaFileContext_t * const pFileContext );
+typedef OtaPalStatus_t ( * OtaPalActivateNewImage_t )( OtaFileContext_t * const pFileContext );
 
 /**
  * @brief Reset the device.
@@ -155,7 +170,7 @@ typedef OtaErr_t ( * OtaPalActivateNewImage_t )( OtaFileContext_t * const pFileC
  * error codes information in ota.h.
  */
 
-typedef OtaErr_t ( * OtaPalResetDevice_t ) ( OtaFileContext_t * const pFileContext );
+typedef OtaPalStatus_t ( * OtaPalResetDevice_t ) ( OtaFileContext_t * const pFileContext );
 
 /**
  * @brief Attempt to set the state of the OTA update image.
@@ -167,19 +182,19 @@ typedef OtaErr_t ( * OtaPalResetDevice_t ) ( OtaFileContext_t * const pFileConte
  *
  * @param[in] eState The desired state of the OTA update image.
  *
- * @return The OtaErr_t error code combined with the MCU specific error code. See ota.h for
+ * @return The OtaPalStatus_t error code combined with the MCU specific error code. See ota.h for
  *         OTA major error codes and your specific PAL implementation for the sub error code.
  *
  * Major error codes returned are:
  *
- *   OTA_ERR_NONE on success.
- *   OTA_ERR_BAD_IMAGE_STATE: if you specify an invalid OtaImageState_t. No sub error code.
- *   OTA_ERR_ABORT_FAILED: failed to roll back the update image as requested by OtaImageStateAborted.
- *   OTA_ERR_REJECT_FAILED: failed to roll back the update image as requested by OtaImageStateRejected.
- *   OTA_ERR_COMMIT_FAILED: failed to make the update image permanent as requested by OtaImageStateAccepted.
+ *   OtaPalSuccess on success.
+ *   OtaPalBadImageState: if you specify an invalid OtaImageState_t. No sub error code.
+ *   OtaPalAbortFailed: failed to roll back the update image as requested by OtaImageStateAborted.
+ *   OtaPalRejectFailed: failed to roll back the update image as requested by OtaImageStateRejected.
+ *   OtaPalCommitFailed: failed to make the update image permanent as requested by OtaImageStateAccepted.
  */
-typedef OtaErr_t ( * OtaPalSetPlatformImageState_t )( OtaFileContext_t * const pFileContext,
-                                                      OtaImageState_t eState );
+typedef OtaPalStatus_t ( * OtaPalSetPlatformImageState_t )( OtaFileContext_t * const pFileContext,
+                                                            OtaImageState_t eState );
 
 /**
  * @brief Get the state of the OTA update image.

--- a/source/portable/os/ota_os_freertos.c
+++ b/source/portable/os/ota_os_freertos.c
@@ -59,9 +59,9 @@ static void requestTimerCallback( TimerHandle_t T );
 static void selfTestTimerCallback( TimerHandle_t T );
 void ( * timerCallback[ OtaNumOfTimers ] )( TimerHandle_t T ) = { requestTimerCallback, selfTestTimerCallback };
 
-OtaErr_t OtaInitEvent_FreeRTOS( OtaEventContext_t * pEventCtx )
+OtaOsStatus_t OtaInitEvent_FreeRTOS( OtaEventContext_t * pEventCtx )
 {
-    OtaErr_t otaErrRet = OTA_ERR_UNINITIALIZED;
+    OtaOsStatus_t otaErrRet = OtaOsSuccess;
 
     ( void ) pEventCtx;
 
@@ -72,7 +72,7 @@ OtaErr_t OtaInitEvent_FreeRTOS( OtaEventContext_t * pEventCtx )
 
     if( otaEventQueue == NULL )
     {
-        otaErrRet = OTA_ERR_EVENT_Q_CREATE_FAILED;
+        otaErrRet = OtaOsEventQueueCreateFailed;
 
         LogError( ( "Failed to create OTA Event Queue: "
                     "xQueueCreateStatic returned error: "
@@ -81,19 +81,17 @@ OtaErr_t OtaInitEvent_FreeRTOS( OtaEventContext_t * pEventCtx )
     }
     else
     {
-        otaErrRet = OTA_ERR_NONE;
-
         LogDebug( ( "OTA Event Queue created." ) );
     }
 
     return otaErrRet;
 }
 
-OtaErr_t OtaSendEvent_FreeRTOS( OtaEventContext_t * pEventCtx,
-                                const void * pEventMsg,
-                                unsigned int timeout )
+OtaOsStatus_t OtaSendEvent_FreeRTOS( OtaEventContext_t * pEventCtx,
+                                     const void * pEventMsg,
+                                     unsigned int timeout )
 {
-    OtaErr_t otaErrRet = OTA_ERR_UNINITIALIZED;
+    OtaOsStatus_t otaErrRet = OtaOsSuccess;
     BaseType_t retVal = pdFALSE;
 
     ( void ) pEventCtx;
@@ -104,13 +102,11 @@ OtaErr_t OtaSendEvent_FreeRTOS( OtaEventContext_t * pEventCtx,
 
     if( retVal == pdTRUE )
     {
-        otaErrRet = OTA_ERR_NONE;
-
         LogDebug( ( "OTA Event Sent." ) );
     }
     else
     {
-        otaErrRet = OTA_ERR_EVENT_Q_SEND_FAILED;
+        otaErrRet = OtaOsEventQueueSendFailed;
 
         LogError( ( "Failed to send event to OTA Event Queue: "
                     "xQueueSendToBack returned error: "
@@ -121,11 +117,11 @@ OtaErr_t OtaSendEvent_FreeRTOS( OtaEventContext_t * pEventCtx,
     return otaErrRet;
 }
 
-OtaErr_t OtaReceiveEvent_FreeRTOS( OtaEventContext_t * pEventCtx,
-                                   void * pEventMsg,
-                                   uint32_t timeout )
+OtaOsStatus_t OtaReceiveEvent_FreeRTOS( OtaEventContext_t * pEventCtx,
+                                        void * pEventMsg,
+                                        uint32_t timeout )
 {
-    OtaErr_t otaErrRet = OTA_ERR_UNINITIALIZED;
+    OtaOsStatus_t otaErrRet = OtaOsSuccess;
     BaseType_t retVal = pdFALSE;
 
     /* Temp buffer.*/
@@ -140,14 +136,11 @@ OtaErr_t OtaReceiveEvent_FreeRTOS( OtaEventContext_t * pEventCtx,
     {
         /* copy the data from local buffer.*/
         memcpy( pEventMsg, buff, MAX_MSG_SIZE );
-
-        otaErrRet = OTA_ERR_NONE;
-
         LogDebug( ( "OTA Event received" ) );
     }
     else
     {
-        otaErrRet = OTA_ERR_EVENT_Q_RECEIVE_FAILED;
+        otaErrRet = OtaOsEventQueueReceiveFailed;
 
         LogError( ( "Failed to receive event from OTA Event Queue: "
                     "xQueueReceive returned error: "
@@ -158,9 +151,9 @@ OtaErr_t OtaReceiveEvent_FreeRTOS( OtaEventContext_t * pEventCtx,
     return otaErrRet;
 }
 
-OtaErr_t OtaDeinitEvent_FreeRTOS( OtaEventContext_t * pEventCtx )
+OtaOsStatus_t OtaDeinitEvent_FreeRTOS( OtaEventContext_t * pEventCtx )
 {
-    OtaErr_t otaErrRet = OTA_ERR_NONE;
+    OtaOsStatus_t otaErrRet = OtaOsSuccess;
 
     ( void ) pEventCtx;
 
@@ -209,12 +202,12 @@ static void requestTimerCallback( TimerHandle_t T )
     }
 }
 
-OtaErr_t OtaStartTimer_FreeRTOS( OtaTimerId_t otaTimerId,
-                                 const char * const pTimerName,
-                                 const uint32_t timeout,
-                                 OtaTimerCallback_t callback )
+OtaOsStatus_t OtaStartTimer_FreeRTOS( OtaTimerId_t otaTimerId,
+                                      const char * const pTimerName,
+                                      const uint32_t timeout,
+                                      OtaTimerCallback_t callback )
 {
-    OtaErr_t otaErrRet = OTA_ERR_UNINITIALIZED;
+    OtaOsStatus_t otaErrRet = OtaOsSuccess;
     BaseType_t retVal = pdFALSE;
 
     configASSERT( callback != NULL );
@@ -233,7 +226,7 @@ OtaErr_t OtaStartTimer_FreeRTOS( OtaTimerId_t otaTimerId,
 
         if( otaTimer[ otaTimerId ] == NULL )
         {
-            otaErrRet = OTA_ERR_EVENT_TIMER_CREATE_FAILED;
+            otaErrRet = OtaOsTimerCreateFailed;
 
             LogError( ( "Failed to create OTA timer: "
                         "timerCreate returned NULL "
@@ -242,8 +235,6 @@ OtaErr_t OtaStartTimer_FreeRTOS( OtaTimerId_t otaTimerId,
         }
         else
         {
-            otaErrRet = OTA_ERR_NONE;
-
             LogDebug( ( "OTA Timer created." ) );
 
             /* Start the timer. */
@@ -251,13 +242,11 @@ OtaErr_t OtaStartTimer_FreeRTOS( OtaTimerId_t otaTimerId,
 
             if( retVal == pdTRUE )
             {
-                otaErrRet = OTA_ERR_NONE;
-
                 LogDebug( ( "OTA Timer started." ) );
             }
             else
             {
-                otaErrRet = OTA_ERR_EVENT_TIMER_START_FAILED;
+                otaErrRet = OtaOsTimerStartFailed;
 
                 LogError( ( "Failed to start OTA timer: "
                             "timerStart returned error." ) );
@@ -271,13 +260,11 @@ OtaErr_t OtaStartTimer_FreeRTOS( OtaTimerId_t otaTimerId,
 
         if( retVal == pdTRUE )
         {
-            otaErrRet = OTA_ERR_NONE;
-
             LogDebug( ( "OTA Timer restarted." ) );
         }
         else
         {
-            otaErrRet = OTA_ERR_EVENT_TIMER_RESTART_FAILED;
+            otaErrRet = OtaOsTimerRestartFailed;
 
             LogError( ( "Failed to set OTA timer timeout: "
                         "timer_settime returned error: "
@@ -289,9 +276,9 @@ OtaErr_t OtaStartTimer_FreeRTOS( OtaTimerId_t otaTimerId,
     return otaErrRet;
 }
 
-OtaErr_t OtaStopTimer_FreeRTOS( OtaTimerId_t otaTimerId )
+OtaOsStatus_t OtaStopTimer_FreeRTOS( OtaTimerId_t otaTimerId )
 {
-    OtaErr_t otaErrRet = OTA_ERR_UNINITIALIZED;
+    OtaOsStatus_t otaErrRet = OtaOsSuccess;
     BaseType_t retVal = pdFALSE;
 
     configASSERT( ( otaTimerId >= OtaRequestTimer ) && ( otaTimerId < OtaNumOfTimers ) );
@@ -304,8 +291,6 @@ OtaErr_t OtaStopTimer_FreeRTOS( OtaTimerId_t otaTimerId )
         if( retVal == pdTRUE )
         {
             LogDebug( ( "OTA Timer Stopped for Timerid=%i.", otaTimerId ) );
-
-            otaErrRet = OTA_ERR_NONE;
         }
         else
         {
@@ -314,22 +299,20 @@ OtaErr_t OtaStopTimer_FreeRTOS( OtaTimerId_t otaTimerId )
                         "otaErrRet=%i ",
                         otaErrRet ) );
 
-            otaErrRet = OTA_ERR_EVENT_TIMER_STOP_FAILED;
+            otaErrRet = OtaOsTimerStopFailed;
         }
     }
     else
     {
         LogWarn( ( "OTA Timer handle NULL for Timerid=%i, can't stop.", otaTimerId ) );
-
-        otaErrRet = OTA_ERR_NONE;
     }
 
     return otaErrRet;
 }
 
-OtaErr_t OtaDeleteTimer_FreeRTOS( OtaTimerId_t otaTimerId )
+OtaOsStatus_t OtaDeleteTimer_FreeRTOS( OtaTimerId_t otaTimerId )
 {
-    OtaErr_t otaErrRet = OTA_ERR_UNINITIALIZED;
+    OtaOsStatus_t otaErrRet = OtaOsSuccess;
     BaseType_t retVal = pdFALSE;
 
     configASSERT( ( otaTimerId >= OtaRequestTimer ) && ( otaTimerId < OtaNumOfTimers ) );
@@ -341,15 +324,12 @@ OtaErr_t OtaDeleteTimer_FreeRTOS( OtaTimerId_t otaTimerId )
 
         if( retVal == pdTRUE )
         {
-            otaErrRet = OTA_ERR_NONE;
-
             otaTimer[ otaTimerId ] == NULL;
-
             LogDebug( ( "OTA Timer deleted." ) );
         }
         else
         {
-            otaErrRet = OTA_ERR_EVENT_TIMER_DELETE_FAILED;
+            otaErrRet = OtaOsTimerDeleteFailed;
 
             LogError( ( "Failed to delete OTA timer: "
                         "timer_delete returned error: "
@@ -359,7 +339,7 @@ OtaErr_t OtaDeleteTimer_FreeRTOS( OtaTimerId_t otaTimerId )
     }
     else
     {
-        otaErrRet = OTA_ERR_EVENT_TIMER_DELETE_FAILED;
+        otaErrRet = OtaOsTimerDeleteFailed;
 
         LogWarn( ( "OTA Timer handle NULL for Timerid=%i, can't delete.", otaTimerId ) );
     }

--- a/source/portable/os/ota_os_freertos.h
+++ b/source/portable/os/ota_os_freertos.h
@@ -39,9 +39,9 @@
  *
  * @param[pEventCtx]     Pointer to the OTA event context.
  *
- * @return               OtaErr_t, OTA_ERR_NONE if success , other error code on failure.
+ * @return               OtaOsStatus_t, OtaOsStatus if success , other error code on failure.
  */
-OtaErr_t OtaInitEvent_FreeRTOS( OtaEventContext_t * pEventCtx );
+OtaOsStatus_t OtaInitEvent_FreeRTOS( OtaEventContext_t * pEventCtx );
 
 /**
  * @brief Sends an OTA event.
@@ -54,11 +54,11 @@ OtaErr_t OtaInitEvent_FreeRTOS( OtaEventContext_t * pEventCtx );
  *
  * @param[timeout]       The maximum amount of time (msec) the task should block.
  *
- * @return               OtaErr_t, OTA_ERR_NONE if success , other error code on failure.
+ * @return               OtaOsStatus_t, OtaOsStatus if success , other error code on failure.
  */
-OtaErr_t OtaSendEvent_FreeRTOS( OtaEventContext_t * pEventCtx,
-                                const void * pEventMsg,
-                                unsigned int timeout );
+OtaOsStatus_t OtaSendEvent_FreeRTOS( OtaEventContext_t * pEventCtx,
+                                     const void * pEventMsg,
+                                     unsigned int timeout );
 
 /**
  * @brief Receive an OTA event.
@@ -71,11 +71,11 @@ OtaErr_t OtaSendEvent_FreeRTOS( OtaEventContext_t * pEventCtx,
  *
  * @param[timeout]       The maximum amount of time the task should block.
  *
- * @return               OtaErr_t, OTA_ERR_NONE if success , other error code on failure.
+ * @return               OtaOsStatus_t, OtaOsStatus if success , other error code on failure.
  */
-OtaErr_t OtaReceiveEvent_FreeRTOS( OtaEventContext_t * pEventCtx,
-                                   void * pEventMsg,
-                                   uint32_t timeout );
+OtaOsStatus_t OtaReceiveEvent_FreeRTOS( OtaEventContext_t * pEventCtx,
+                                        void * pEventMsg,
+                                        uint32_t timeout );
 
 /**
  * @brief Deinitialize the OTA Events mechanism.
@@ -85,9 +85,9 @@ OtaErr_t OtaReceiveEvent_FreeRTOS( OtaEventContext_t * pEventCtx,
  *
  * @param[pEventCtx]     Pointer to the OTA event context.
  *
- * @return               OtaErr_t, OTA_ERR_NONE if success , other error code on failure.
+ * @return               OtaOsStatus_t, OtaOsStatus if success , other error code on failure.
  */
-OtaErr_t OtaDeinitEvent_FreeRTOS( OtaEventContext_t * pEventCtx );
+OtaOsStatus_t OtaDeinitEvent_FreeRTOS( OtaEventContext_t * pEventCtx );
 
 
 /**
@@ -103,12 +103,12 @@ OtaErr_t OtaDeinitEvent_FreeRTOS( OtaEventContext_t * pEventCtx );
  *
  * @param[callback]         Callback to be called when timer expires.
  *
- * @return                  OtaErr_t, OTA_ERR_NONE if success , other error code on failure.
+ * @return                  OtaOsStatus_t, OtaOsStatus if success , other error code on failure.
  */
-OtaErr_t OtaStartTimer_FreeRTOS( OtaTimerId_t otaTimerId,
-                                 const char * const pTimerName,
-                                 const uint32_t timeout,
-                                 OtaTimerCallback_t callback );
+OtaOsStatus_t OtaStartTimer_FreeRTOS( OtaTimerId_t otaTimerId,
+                                      const char * const pTimerName,
+                                      const uint32_t timeout,
+                                      OtaTimerCallback_t callback );
 
 /**
  * @brief Stop timer.
@@ -117,9 +117,9 @@ OtaErr_t OtaStartTimer_FreeRTOS( OtaTimerId_t otaTimerId,
  *
  * @param[otaTimerId]     Timer ID of type otaTimerId_t.
  *
- * @return                OtaErr_t, OTA_ERR_NONE if success , other error code on failure.
+ * @return                OtaOsStatus_t, OtaOsStatus if success , other error code on failure.
  */
-OtaErr_t OtaStopTimer_FreeRTOS( OtaTimerId_t otaTimerId );
+OtaOsStatus_t OtaStopTimer_FreeRTOS( OtaTimerId_t otaTimerId );
 
 /**
  * @brief Delete a timer.
@@ -128,9 +128,9 @@ OtaErr_t OtaStopTimer_FreeRTOS( OtaTimerId_t otaTimerId );
  *
  * @param[otaTimerId]       Timer ID of type otaTimerId_t.
  *
- * @return                  OtaErr_t, OTA_ERR_NONE if success , other error code on failure.
+ * @return                  OtaOsStatus_t, OtaOsStatus if success , other error code on failure.
  */
-OtaErr_t OtaDeleteTimer_FreeRTOS( OtaTimerId_t otaTimerId );
+OtaOsStatus_t OtaDeleteTimer_FreeRTOS( OtaTimerId_t otaTimerId );
 
 /**
  * @brief Allocate memory.

--- a/source/portable/os/ota_os_posix.h
+++ b/source/portable/os/ota_os_posix.h
@@ -46,9 +46,9 @@ struct OtaTimerContext
  *
  * @param[pEventCtx]     Pointer to the OTA event context.
  *
- * @return               OtaErr_t, OTA_ERR_NONE if success , other error code on failure.
+ * @return               OtaOsStatus_t, OtaOsSuccess if success , other error code on failure.
  */
-OtaErr_t Posix_OtaInitEvent( OtaEventContext_t * pEventCtx );
+OtaOsStatus_t Posix_OtaInitEvent( OtaEventContext_t * pEventCtx );
 
 /**
  * @brief Sends an OTA event.
@@ -61,11 +61,11 @@ OtaErr_t Posix_OtaInitEvent( OtaEventContext_t * pEventCtx );
  *
  * @param[timeout]       The maximum amount of time (msec) the task should block.
  *
- * @return               OtaErr_t, OTA_ERR_NONE if success , other error code on failure.
+ * @return               OtaOsStatus_t, OtaOsSuccess if success , other error code on failure.
  */
-OtaErr_t Posix_OtaSendEvent( OtaEventContext_t * pEventCtx,
-                             const void * pEventMsg,
-                             unsigned int timeout );
+OtaOsStatus_t Posix_OtaSendEvent( OtaEventContext_t * pEventCtx,
+                                  const void * pEventMsg,
+                                  unsigned int timeout );
 
 /**
  * @brief Receive an OTA event.
@@ -78,11 +78,11 @@ OtaErr_t Posix_OtaSendEvent( OtaEventContext_t * pEventCtx,
  *
  * @param[timeout]       The maximum amount of time the task should block.
  *
- * @return               OtaErr_t, OTA_ERR_NONE if success , other error code on failure.
+ * @return               OtaOsStatus_t, OtaOsSuccess if success , other error code on failure.
  */
-OtaErr_t Posix_OtaReceiveEvent( OtaEventContext_t * pEventCtx,
-                                void * pEventMsg,
-                                uint32_t timeout );
+OtaOsStatus_t Posix_OtaReceiveEvent( OtaEventContext_t * pEventCtx,
+                                     void * pEventMsg,
+                                     uint32_t timeout );
 
 /**
  * @brief Deinitialize the OTA Events mechanism.
@@ -92,9 +92,9 @@ OtaErr_t Posix_OtaReceiveEvent( OtaEventContext_t * pEventCtx,
  *
  * @param[pEventCtx]     Pointer to the OTA event context.
  *
- * @return               OtaErr_t, OTA_ERR_NONE if success , other error code on failure.
+ * @return               OtaOsStatus_t, OtaOsSuccess if success , other error code on failure.
  */
-OtaErr_t Posix_OtaDeinitEvent( OtaEventContext_t * pEventCtx );
+OtaOsStatus_t Posix_OtaDeinitEvent( OtaEventContext_t * pEventCtx );
 
 
 /**
@@ -110,12 +110,12 @@ OtaErr_t Posix_OtaDeinitEvent( OtaEventContext_t * pEventCtx );
  *
  * @param[callback]         Callback to be called when timer expires.
  *
- * @return                  OtaErr_t, OTA_ERR_NONE if success , other error code on failure.
+ * @return                  OtaOsStatus_t, OtaOsSuccess if success , other error code on failure.
  */
-OtaErr_t Posix_OtaStartTimer( OtaTimerId_t otaTimerId,
-                              const char * const pTimerName,
-                              const uint32_t timeout,
-                              OtaTimerCallback_t callback );
+OtaOsStatus_t Posix_OtaStartTimer( OtaTimerId_t otaTimerId,
+                                   const char * const pTimerName,
+                                   const uint32_t timeout,
+                                   OtaTimerCallback_t callback );
 
 /**
  * @brief Stop timer.
@@ -124,9 +124,9 @@ OtaErr_t Posix_OtaStartTimer( OtaTimerId_t otaTimerId,
  *
  * @param[otaTimerId]     Timer ID of type otaTimerId_t.
  *
- * @return                OtaErr_t, OTA_ERR_NONE if success , other error code on failure.
+ * @return                OtaOsStatus_t, OtaOsSuccess if success , other error code on failure.
  */
-OtaErr_t Posix_OtaStopTimer( OtaTimerId_t otaTimerId );
+OtaOsStatus_t Posix_OtaStopTimer( OtaTimerId_t otaTimerId );
 
 /**
  * @brief Delete a timer.
@@ -135,9 +135,9 @@ OtaErr_t Posix_OtaStopTimer( OtaTimerId_t otaTimerId );
  *
  * @param[otaTimerId]       Timer ID of type otaTimerId_t.
  *
- * @return                  OtaErr_t, OTA_ERR_NONE if success , other error code on failure.
+ * @return                  OtaOsStatus_t, OtaOsSuccess if success , other error code on failure.
  */
-OtaErr_t Posix_OtaDeleteTimer( OtaTimerId_t otaTimerId );
+OtaOsStatus_t Posix_OtaDeleteTimer( OtaTimerId_t otaTimerId );
 
 /**
  * @brief Allocate memory.


### PR DESCRIPTION
## Proposal for replacing the `OtaErr_t` typedef with enums.

The goal is to get rid of the circular includes between `ota.h` and interface headers. Basically `OtaErr_t` is defined in ota.h and required these interface headers,

- `ota_mqtt_interface.h`
- `ota_http_interface.h`
- `ota_os_interface.h`
- `ota_platform_interface`

The proposal in this PR is to have separate error enum defined for each interface instead of using the `OtaErr_t` from ota.h. Because we still want the underlying integers in these error enums to have different values so that we can compose them together to report to the cloud, we define ranges for each error enums,

- OTA agent: 0 - 0x7F
- OTA OS interface: 0x80 - 0x9F
- OTA MQTT interface: 0xA0 - 0xBF
- OTA HTTP interface: 0xC0 - 0xDF
- OTA PAL inteface: 0xE0 - 0xFF

So OTA agent can define up to 128 different errors, whereas each interface can define up to 32 different errors.